### PR TITLE
Starting to add support for numeric suffixes.

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -99,23 +99,23 @@ patterns:
 
 - comment: A float literal
   name: constant.numeric.float.decimal.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(\d[_\d]*((\.[_\d]+([eE][\+\-]?\d[_\d]*)?)|([eE][\+\-]?\d[_\d]*)))('?([fF](32|64|128))|[fFdD])?   #' highlight-flaw-fixer-comment
+  match: (?<![\w\x{80}-\x{10FFFF}])(\d[_\d]*((\.[_\d]+([eE][\+\-]?\d[_\d]*)?)|([eE][\+\-]?\d[_\d]*)))('?([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[fFdD])?   #' highlight-flaw-fixer-comment
 
 - comment: A hexadecimal literal
   name: constant.numeric.integer.hexadecimal.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?   #' highlight-flaw-fixer-comment
+  match: (?<![\w\x{80}-\x{10FFFF}])(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?   #' highlight-flaw-fixer-comment
 
 - comment: A base-8 integer literal
   name: constant.numeric.integer.octal.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(0[ocC][0-7][_0-7]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?   #' highlight-flaw-fixer-comment
+  match: (?<![\w\x{80}-\x{10FFFF}])(0[ocC][0-7][_0-7]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?   #' highlight-flaw-fixer-comment
 
 - comment: A base-2 integer literal
   name: constant.numeric.integer.binary.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(0(b|B)[01][_01]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?   #' highlight-flaw-fixer-comment
+  match: (?<![\w\x{80}-\x{10FFFF}])(0(b|B)[01][_01]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?   #' highlight-flaw-fixer-comment
 
 - comment: A base-10 integer literal
   name: constant.numeric.integer.decimal.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(\d[_\d]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?   #' highlight-flaw-fixer-comment
+  match: (?<![\w\x{80}-\x{10FFFF}])(\d[_\d]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?   #' highlight-flaw-fixer-comment
 
 - comment: Language Constants.
   name: constant.language.nim
@@ -251,12 +251,7 @@ patterns:
 
 - comment: Single quoted character literal
   name: string.quoted.single.nim
-  begin: \'
-  end: \'
-  patterns:
-    - include: '#escaped_char'
-    - name: invalid.illegal.character.nim
-      match: ([^\'][^\']+?)   #' highlight-flaw-fixer-comment
+  match: \'(.|\\\w)\'
 
 - comment: Call syntax
   begin: ([\w\x{80}-\x{10FFFF}\`]+)\s*(?=\(|\[.+?\]\s*\()

--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -251,7 +251,15 @@ patterns:
 
 - comment: Single quoted character literal
   name: string.quoted.single.nim
-  match: \'(.|\\\w)\'
+  match: \'([^\\]|\\x[0-9A-Fa-f][0-9A-Fa-f]|\\\d+|\\[abceflnrtv\\\"\'])\'
+
+- comment: Flawed single quoted character literal escaped
+  name: invalid.illegal.character.nim
+  match: \'\\[^abceflnrtv\\\"\']\'
+
+- comment: Flawed single quoted character literal other adjacent
+  name: invalid.illegal.character.nim
+  match: \'[A-Fa-f0-9\x{80}-\x{10FFFF}][A-Fa-f0-9\x{80}-\x{10FFFF}]+\'
 
 - comment: Call syntax
   begin: ([\w\x{80}-\x{10FFFF}\`]+)\s*(?=\(|\[.+?\]\s*\()

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -646,9 +646,25 @@
 			<key>comment</key>
 			<string>Single quoted character literal</string>
 			<key>match</key>
-			<string>\'(.|\\\w)\'</string>
+			<string>\'([^\\]|\\x[0-9A-Fa-f][0-9A-Fa-f]|\\\d+|\\[abceflnrtv\\\"\'])\'</string>
 			<key>name</key>
 			<string>string.quoted.single.nim</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Flawed single quoted character literal escaped</string>
+			<key>match</key>
+			<string>\'\\[^abceflnrtv\\\"\']\'</string>
+			<key>name</key>
+			<string>invalid.illegal.character.nim</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Flawed single quoted character literal other adjacent</string>
+			<key>match</key>
+			<string>\'[A-Fa-f0-9\x{80}-\x{10FFFF}][A-Fa-f0-9\x{80}-\x{10FFFF}]+\'</string>
+			<key>name</key>
+			<string>invalid.illegal.character.nim</string>
 		</dict>
 		<dict>
 			<key>begin</key>

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -278,7 +278,7 @@
 			<key>comment</key>
 			<string>A float literal</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(\d[_\d]*((\.[_\d]+([eE][\+\-]?\d[_\d]*)?)|([eE][\+\-]?\d[_\d]*)))('?([fF](32|64|128))|[fFdD])?</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(\d[_\d]*((\.[_\d]+([eE][\+\-]?\d[_\d]*)?)|([eE][\+\-]?\d[_\d]*)))('?([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[fFdD])?</string>
 			<key>name</key>
 			<string>constant.numeric.float.decimal.nim</string>
 		</dict>
@@ -286,7 +286,7 @@
 			<key>comment</key>
 			<string>A hexadecimal literal</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.hexadecimal.nim</string>
 		</dict>
@@ -294,7 +294,7 @@
 			<key>comment</key>
 			<string>A base-8 integer literal</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0[ocC][0-7][_0-7]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0[ocC][0-7][_0-7]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.octal.nim</string>
 		</dict>
@@ -302,7 +302,7 @@
 			<key>comment</key>
 			<string>A base-2 integer literal</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0(b|B)[01][_01]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0(b|B)[01][_01]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.binary.nim</string>
 		</dict>
@@ -310,7 +310,7 @@
 			<key>comment</key>
 			<string>A base-10 integer literal</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(\d[_\d]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(\d[_\d]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.decimal.nim</string>
 		</dict>
@@ -643,27 +643,12 @@
 			</array>
 		</dict>
 		<dict>
-			<key>begin</key>
-			<string>\'</string>
 			<key>comment</key>
 			<string>Single quoted character literal</string>
-			<key>end</key>
-			<string>\'</string>
+			<key>match</key>
+			<string>\'(.|\\\w)\'</string>
 			<key>name</key>
 			<string>string.quoted.single.nim</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#escaped_char</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>([^\'][^\']+?)</string>
-					<key>name</key>
-					<string>invalid.illegal.character.nim</string>
-				</dict>
-			</array>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
until https://github.com/Varriount/NimLime/pull/153 is merged upstream, i'm create a master2 branch and will try to make github linguist point to it so that number literals show up correctly

## links
* [Add support for numeric suffixes. by JohnAD · Pull Request #153 · Varriount/NimLime](https://github.com/Varriount/NimLime/pull/153)
* [move this repo to nim-lang/NimLime ? · Issue #154 · Varriount/NimLime](https://github.com/Varriount/NimLime/issues/154)
* [misc problems with number literals · Issue #17504 · nim-lang/Nim](https://github.com/nim-lang/Nim/issues/17504)